### PR TITLE
Add File - VariantThemes.cfg

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/VariantThemes.cfg
+++ b/Gamedata/Bluedog_DB/Parts/VariantThemes.cfg
@@ -1,0 +1,65 @@
+VARIANTTHEME
+{
+	name = Logo
+	displayName = Logo
+	themeName = Logo
+	primaryColor = #396cbf
+	secondaryColor = #2f3030
+}
+VARIANTTHEME
+{
+	name = BDB
+	displayName = BDB
+	themeName = BDB
+	primaryColor = #bdbfbf
+	secondaryColor = #2f3030
+}
+VARIANTTHEME
+{
+	name = Titan
+	displayName = Titan
+	themeName = Titan
+	primaryColor = #2f3030
+	secondaryColor = #2f3030
+}
+VARIANTTHEME
+{
+	name = Etoh
+	displayName = Etoh
+	themeName = Etoh
+	primaryColor = #bdbfbf
+	secondaryColor = #c97878
+}
+VARIANTTHEME
+{
+	name = EtohTest
+	displayName = Etoh Test
+	themeName = Etoh Test
+	primaryColor = #f9df1b
+	secondaryColor = #c97878
+}
+
+VARIANTTHEME
+{
+	name = BDB_Brown
+	displayName = BDB Brown
+	themeName = BDB Brown
+	primaryColor = #7b5545
+	secondaryColor = #7b5545
+}
+VARIANTTHEME
+{
+	name = BDB_Delta
+	displayName = BDB Delta
+	themeName = BDB Delta
+	primaryColor = #f7f3f7
+	secondaryColor = #f7f3f7
+}
+VARIANTTHEME
+{
+	name = BDB_Red
+	displayName = BDB Red
+	themeName = BDB Red
+	primaryColor = #702f2e
+	secondaryColor = #702f2e
+}


### PR DESCRIPTION
Fixes missing VARIANTTHEME
[ERR 12:51:14.051] Unable to find theme named:'Logo' in GameDB
[ERR 12:51:14.051] Unable to find theme named:'BDB' in GameDB
[ERR 12:51:14.051] Unable to find theme named:'Titan' in GameDB
[ERR 12:51:14.051] Unable to find theme named:'Etoh' in GameDB
[ERR 12:51:14.051] Unable to find theme named:'Etoh Test' in GameDB
[ERR 12:51:14.051] Unable to find theme named:'BDB Brown' in GameDB
[ERR 12:51:14.051] Unable to find theme named:'BDB Delta' in GameDB
[ERR 12:51:14.051] Unable to find theme named:'BDB Red' in GameDB